### PR TITLE
fix: HamburgerMenu duplication bug

### DIFF
--- a/src/components/navbar/Navbar.styled.tsx
+++ b/src/components/navbar/Navbar.styled.tsx
@@ -146,6 +146,7 @@ export const HamburgerMenu = styled.button<{
 
 	mask-image: url(${({ $open, $hamburgerIcon, $closeIcon }) =>
 		$open ? $closeIcon : $hamburgerIcon});
+	mask-repeat: no-repeat;
 	background-color: ${({ $color }) => ($color === 'warn' ? BLACK : WHITE)};
 `;
 


### PR DESCRIPTION
## Summary

<!-- Explain what you're trying to archive with this pull request. Provide design URLs in the `References` if needed. -->
Fixed an issue where the HamburgerMenu's hamburgerIcon and closeIcon were being duplicated on mobile devices.

fixes #16 

