### PR TITLE
Fix CI hang by scoping lint to src/

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"build": "tsup && tsc -p tsconfig.build.json && cp dist/index.d.ts dist/index.d.mts",
 		"build:storybook": "storybook build -o docs-build",
 		"changeset": "changeset",
-		"lint": "eslint . --ext .ts,.tsx,.js,.jsx",
+		"lint": "eslint src --ext .ts,.tsx",
 		"prepare": "husky install",
 		"prepublishOnly": "npm run build",
 		"release": "changeset publish",


### PR DESCRIPTION
## Summary

The 1.5.0 release workflow hung on the Lint step for 12+ minutes (then was cancelled) even though `eslint src` runs in ~5 seconds locally. Root cause: `npm run lint` was `eslint . --ext .ts,.tsx,.js,.jsx`, which makes ESLint traverse far more than the source tree. Narrowing the script to `eslint src --ext .ts,.tsx` matches what was being run locally and keeps lint feedback on the files that matter.

## Test plan

- [x] `npm run lint` local: 3.4s, 0 errors, 4 intentional warnings
- [ ] CI release workflow finishes Lint + Test and opens the Version Packages PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)