### PR TITLE
Fix ProgressBar loop seam and Button height for 1.5.2

### DIFF
--- a/.changeset/fix-progress-button-1-5-2.md
+++ b/.changeset/fix-progress-button-1-5-2.md
@@ -1,0 +1,9 @@
+---
+'retro-react': patch
+---
+
+Two small fixes found in real-consumer testing of 1.5.1.
+
+ProgressBar animation loop now cycles seamlessly. The previous shift of `8px` per cycle was the stripe period along the gradient axis, but at 45 degrees that projects to `8 / √2` ≈ 5.66 horizontal pixels, not 8. The pattern was almost-but-not-quite returning to the same visual position at the loop boundary and you could see the jump. The shift is now `8 × √2` ≈ 11.31px, which is exactly one stripe period along the diagonal.
+
+Button heights now actually match form fields. 1.5.1 sized buttons with content-box math, but Button is `box-sizing: border-box`, so the external box ended up 8px shorter than Input / Select / Autocomplete. Heights bumped to 28 / 32 / 36 (small / medium / large) so a Button sits the same height as a same-size Input in the same row.

--- a/src/components/button/Button.styled.tsx
+++ b/src/components/button/Button.styled.tsx
@@ -156,11 +156,11 @@ export const Button = styled.button<{
 	height: ${(props) => {
 		switch (props.$size) {
 			case 'small':
-				return '20px';
-			case 'large':
 				return '28px';
+			case 'large':
+				return '36px';
 			default:
-				return '24px';
+				return '32px';
 		}
 	}};
 

--- a/src/components/progress_bar/ProgressBar.styled.tsx
+++ b/src/components/progress_bar/ProgressBar.styled.tsx
@@ -9,7 +9,7 @@ const progressAnimation = keyframes`
 		background-position: 0 0;
 	}
 	100% {
-		background-position: 8px 0;
+		background-position: 11.3137px 0;
 	}
 `;
 


### PR DESCRIPTION
## Summary

Two small fixes found while testing 1.5.1 in a fresh consumer project.

ProgressBar animation no longer has a visible jump at the loop boundary. The shift is now `8 * √2` ≈ 11.31px (one full stripe period along the diagonal) instead of `8px` (which projected to half a stripe along the 45-degree gradient axis).

Button heights actually match form fields now. 1.5.1 sized buttons in content-box math but Button is border-box, so the external box was 8px shorter. Bumped to 28 / 32 / 36 to align with Input / Select / Autocomplete.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` 22/22
- [x] `npm run lint` 0 errors
- [ ] Release workflow finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)